### PR TITLE
S3 bucket naming, clarity around domain name parameters

### DIFF
--- a/templates/Application.yaml
+++ b/templates/Application.yaml
@@ -15,6 +15,12 @@ Parameters:
     Description: The base FQDN associated with your r53 Hosted Zone
     Type: String
   ProjectId:
+    AllowedPattern: '[a-z]*'
+    ConstraintDescription: Must begin with a letter and contain only alphanumeric characters. 
+    Default: arc
+    Description: The name of the project
+    MaxLength: '64'
+    MinLength: '1'
     Type: String
   PrimaryRegion:
     Description: Is this a Primary region?

--- a/templates/Application.yaml
+++ b/templates/Application.yaml
@@ -11,7 +11,10 @@ Parameters:
   LatestAmiId:
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
-  CerticateFqDomainName:
+  DNSDomainName:
+    Description: The base FQDN associated with your r53 Hosted Zone
+    Type: String
+  ProjectId:
     Type: String
   PrimaryRegion:
     Description: Is this a Primary region?
@@ -516,7 +519,7 @@ Resources:
   AcmCertificate:
     Type: "AWS::CertificateManager::Certificate"
     Properties: 
-      DomainName: !Ref CerticateFqDomainName
+      DomainName: !Sub ${ProjectId}.${DNSDomainName}
       ValidationMethod: DNS
   
   NLBListener:

--- a/templates/ArcShared.yaml
+++ b/templates/ArcShared.yaml
@@ -3,8 +3,7 @@ Description: 'Amazon Route53 Application Recovery Controller cluster and routing
 Parameters:
   ProjectId:
     AllowedPattern: '[a-z]*'
-    ConstraintDescription: Must begin with a letter and contain only alphanumeric
-      characters.
+    ConstraintDescription: Must begin with a letter and contain only alphanumeric characters. Must be the same project name entered as a parameter for the "Application" Cloudformation Template. 
     Default: arc
     Description: The name of the project
     MaxLength: '64'
@@ -14,7 +13,7 @@ Parameters:
     Description: The r53 Hosted Zone Id
     Type: AWS::Route53::HostedZone::Id
   DNSDomainName:
-    Description: The base FQDN associated with the r53 Hosted Zone provided
+    Description: The base FQDN associated with the Route53 Hosted Zone provided. Must be the same FQDN entered as a parameter for the "Application" Cloudformation Template. 
     Type: String
   Cell1LocationFriendlyName:
     Description: The location of cell 1 (used for naming things)
@@ -50,7 +49,7 @@ Resources:
   SyntheticsBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "${ProjectId}-synthetics-results"
+      BucketName: !Sub "${ProjectId}-synthetics-results-${AWS::StackId}"
       AccessControl: Private
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
@@ -95,7 +94,7 @@ Resources:
     Type: 'AWS::Synthetics::Canary'
     DependsOn: SyntheticsBucket
     Properties:
-      Name: !Sub "${ProjectId}-arc-canary"
+      Name: !Sub "${ProjectId}-canary"
       ExecutionRoleArn: !GetAtt SyntheticsExecutionRole.Arn
       Code: {Handler: pageLoadBlueprint.handler, Script: !Sub "var synthetics = require('Synthetics');\nconst log = require('SyntheticsLogger');\nconst pageLoadBlueprint = async function () {\n// INSERT URL here\nconst URL = \"https://${ProjectId}.${DNSDomainName}\";\n\nlet page = await synthetics.getPage();\nconst response = await page.goto(URL, {waitUntil: 'domcontentloaded', timeout: 30000});\n//Wait for page to render.\n//Increase or decrease wait time based on endpoint being monitored.\nawait page.waitFor(15000);\nawait synthetics.takeScreenshot('loaded', 'loaded');\nlet pageTitle = await page.title();\nlog.info('Page title: ' + pageTitle);\nif (response.status() !== 200) {\n     throw \"Failed to load page!\";\n}\n};\n\nexports.handler = async () => {\nreturn await pageLoadBlueprint();\n};\n"}
       ArtifactS3Location: !Sub "s3://${SyntheticsBucket}"


### PR DESCRIPTION
This PR makes a few additions and changes to the parameters:

1. S3 bucket requires a unique name so AWS::StackId has been added to the S3 bucket name to ensure it's uniqueness
2. DNS name in Application stack and ArcShared stack must be the same, so ProjectId has added to Application stack to make sure the fqdn is the same for the cert and r53 entries. Instruction has been added to allow the user to know that this info must be the same in both stacks.
3. Synthetics Canary name was shortened, as Synthentics Canary names must be 21 chars or less. **This does not fix this issue, only makes it less likely to fail**, I'll open an issue for this to be fixed on the main repo. 

Shout if there's anything wrong here or needs amending. Thanks!